### PR TITLE
Implements fix where user cannot delete empty experiences or employments

### DIFF
--- a/src/component/Education.js
+++ b/src/component/Education.js
@@ -5,6 +5,7 @@ import { useSnackbar } from 'notistack';
 const Education = ({ experiences, setExperiences, getExperiences }) => {
   const { enqueueSnackbar } = useSnackbar();
   const [ newEducation, setNewEducation ] = useState(false);
+
   // Handle the input changes for both experience and education
   const handleInputChange = (e, index, type, field) => {
     const updatedExperience = [...experiences[type]];
@@ -31,6 +32,17 @@ const Education = ({ experiences, setExperiences, getExperiences }) => {
   const removeEducation = async (index) => {
     const updatedEducation = [...experiences.educations];
     const removedEducation = updatedEducation.splice(index, 1)[0];
+
+    // Check if the removedEducation contains only empty strings
+    const isEmptyEducation = removedEducation &&
+        Object.values(removedEducation).every(value => value === '');
+
+    if (!removedEducation || isEmptyEducation) {
+      setExperiences({ ...experiences, educations: updatedEducation });
+      enqueueSnackbar('Education Deleted', { variant: 'success' });
+      return;
+    }
+
     const data = { id: removedEducation.id }
 
     try {
@@ -41,7 +53,7 @@ const Education = ({ experiences, setExperiences, getExperiences }) => {
         headers: {
           'Authorization': `Bearer ${localStorage.getItem('token')}`
         },
-        withCredentials: true 
+        withCredentials: true
       });
 
       if (response.data.success) {
@@ -55,10 +67,10 @@ const Education = ({ experiences, setExperiences, getExperiences }) => {
       enqueueSnackbar('Error deleting employment', { variant: 'error' });
     }
   };
-  
+
   const handleSaveEducationClick = async (index) => {
     const eduData = experiences.educations[index];
-  
+
     // Prepare the data to be sent to the backend
     const data = {
       experienceType: 'Education',
@@ -71,20 +83,20 @@ const Education = ({ experiences, setExperiences, getExperiences }) => {
         endDate: eduData.endDate,
       },
     };
-  
+
     const config = {
       headers: {
         Authorization: `Bearer ${localStorage.getItem('token')}`,
       },
       withCredentials: true,
     };
-  
+
     try {
       const apiUrl = 'http://localhost:8000/api/v1/experiences';
       const response = newEducation
         ? await axios.post(apiUrl, data, config)
         : await axios.put(`${apiUrl}/${eduData.experienceId}`, data, config);
-  
+
       if (response.data.success) {
         setNewEducation(false);
         getExperiences();
@@ -96,7 +108,7 @@ const Education = ({ experiences, setExperiences, getExperiences }) => {
       enqueueSnackbar('Error saving experience', { variant: 'error' });
     }
   };
-  
+
 
   return (
     <div>
@@ -180,7 +192,7 @@ const Education = ({ experiences, setExperiences, getExperiences }) => {
       </button>
     </div>
   );
-  
+
 };
 
 export default Education;

--- a/src/component/Employment.js
+++ b/src/component/Employment.js
@@ -5,6 +5,7 @@ import { useSnackbar } from 'notistack';
 const Employment = ({ experiences, setExperiences, getExperiences }) => {
   const { enqueueSnackbar } = useSnackbar();
   const [ newEmployment, setNewEmployment ] = useState(false);
+
   // Handle the input changes for both experience and education
   const handleInputChange = (e, index, type, field) => {
     const updatedExperience = [...experiences[type]];
@@ -27,34 +28,50 @@ const Employment = ({ experiences, setExperiences, getExperiences }) => {
     setNewEmployment(true);
   };
 
-  // Remove an experience entry
   const removeEmployment = async (index) => {
+
+    // Copy and remove the employment entry from the local state
     const updatedExperience = [...experiences.employments];
     const removedEmployment = updatedExperience.splice(index, 1)[0];
-    const data = { id: removedEmployment.id }
+
+    // Check if the removedEmployment contains any data
+    const isEmptyEmployment = removedEmployment &&
+        Object.values(removedEmployment).every(value => value === '');
+
+    if (!removedEmployment || isEmptyEmployment) {
+      setExperiences({ ...experiences, employments: updatedExperience });
+      enqueueSnackbar('Employment Deleted', { variant: 'success' });
+      return;
+    }
+
+    const data = { id: removedEmployment.id };
 
     try {
+
       const response = await axios.delete(
-        `http://localhost:8000/api/v1/experiences/${removedEmployment.experienceId}`,
-      {
-        data,
-        headers: {
-          'Authorization': `Bearer ${localStorage.getItem('token')}`
-        },
-        withCredentials: true 
-      });
+          `http://localhost:8000/api/v1/experiences/${removedEmployment.experienceId}`,
+          {
+            data,
+            headers: {
+              'Authorization': `Bearer ${localStorage.getItem('token')}`
+            },
+            withCredentials: true
+          }
+      );
 
       if (response.data.success) {
         setExperiences({ ...experiences, employments: updatedExperience });
-        getExperiences()
+        getExperiences();
         enqueueSnackbar('Employment Deleted', { variant: 'success' });
       } else {
         enqueueSnackbar('Failed to delete employment', { variant: 'error' });
       }
-    } catch {
+    } catch (error) {
       enqueueSnackbar('Error deleting employment', { variant: 'error' });
     }
   };
+
+
 
   const handleSaveEmploymentExperienceClick = async (index) => {
     const expData = experiences.employments[index];
@@ -77,7 +94,7 @@ const Employment = ({ experiences, setExperiences, getExperiences }) => {
       },
       withCredentials: true,
     };
-  
+
 
     try {
       const apiUrl = 'http://localhost:8000/api/v1/experiences';


### PR DESCRIPTION
Implements bug fix for users not being able to delete empty employments or education. This fix applies to newly created experiences which do not exist in the database.  This fix checks if all the fields are empty, if they are empty, it allows the user to bypass the API call and remove the employment or education experiences locally.